### PR TITLE
upgrage deps to dedupe in ipfs-car

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,14 +6,14 @@
   "packages": {
     "": {
       "name": "@web3-storage/car-block-validator",
-      "version": "1.0.1",
-      "license": "(Apache-2.0 AND MIT)",
+      "version": "1.2.0",
+      "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@multiformats/blake2": "^1.0.13",
-        "@multiformats/murmur3": "^1.1.3",
+        "@multiformats/blake2": "^2.0.2",
+        "@multiformats/murmur3": "^2.1.8",
         "@multiformats/sha3": "^2.0.15",
-        "multiformats": "9.9.0",
-        "uint8arrays": "^3.1.1"
+        "multiformats": "^13.3.1",
+        "uint8arrays": "^5.1.0"
       },
       "devDependencies": {
         "@ipld/car": "^5.1.0",
@@ -198,21 +198,27 @@
       }
     },
     "node_modules/@multiformats/blake2": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@multiformats/blake2/-/blake2-1.0.13.tgz",
-      "integrity": "sha512-T1Kzya0wjj85CaVeRSpJ858EnSvW1pw94GSitxYf84VsNdv5XYbJ6QG8y26Ft1bVALzrUCmqkQrR53QHSyu6RA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/blake2/-/blake2-2.0.2.tgz",
+      "integrity": "sha512-AOWu6Tyuk5UoT5m4faB6ntVnPB8EmuD6rn18s4cCgHNEGgsamT8GdvjP9DYjzFHQVaP/0L3CaKqWQqJlXx9ecw==",
+      "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "blakejs": "^1.1.1",
-        "multiformats": "^9.5.4"
+        "blakejs": "^1.2.1",
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/@multiformats/murmur3": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-1.1.3.tgz",
-      "integrity": "sha512-wAPLUErGR8g6Lt+bAZn6218k9YQPym+sjszsXL6o4zfxbA22P+gxWZuuD9wDbwL55xrKO5idpcuQUX7/E3oHcw==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.8.tgz",
+      "integrity": "sha512-6vId1C46ra3R1sbJUOFCZnsUIveR9oF20yhPmAFxPm0JfrX3/ZRCgP3YDrBzlGoEppOXnA9czHeYc0T9mB6hbA==",
+      "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "multiformats": "^9.5.4",
+        "multiformats": "^13.0.0",
         "murmurhash3js-revisited": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@multiformats/sha3": {
@@ -223,6 +229,12 @@
         "js-sha3": "^0.8.0",
         "multiformats": "^9.5.4"
       }
+    },
+    "node_modules/@multiformats/sha3/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -3109,9 +3121,10 @@
       "dev": true
     },
     "node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.3.1.tgz",
+      "integrity": "sha512-QxowxTNwJ3r5RMctoGA5p13w5RbRT2QDkoM+yFlqfLiioBp78nhDjnRLvmSBI9+KAqN4VdgOVWM9c0CHd86m3g==",
+      "license": "Apache-2.0 OR MIT"
     },
     "node_modules/murmurhash3js-revisited": {
       "version": "3.0.0",
@@ -4712,11 +4725,12 @@
       }
     },
     "node_modules/uint8arrays": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
-      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "multiformats": "^9.4.2"
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "block"
   ],
   "dependencies": {
-    "@multiformats/blake2": "^1.0.13",
-    "@multiformats/murmur3": "^1.1.3",
+    "@multiformats/blake2": "^2.0.2",
+    "@multiformats/murmur3": "^2.1.8",
     "@multiformats/sha3": "^2.0.15",
-    "multiformats": "9.9.0",
-    "uint8arrays": "^3.1.1"
+    "multiformats": "^13.3.1",
+    "uint8arrays": "^5.1.0"
   },
   "devDependencies": {
     "@ipld/car": "^5.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ import {
   keccak512
 // @ts-expect-error types not well published
 } from '@multiformats/sha3'
-import { equals } from 'uint8arrays'
+import { equals } from 'uint8arrays/equals'
 
 /**
  * @typedef {object} Block


### PR DESCRIPTION
ipfs-car currently includes multiple versions of multiformats, uint8arrays and other libs. This PR addresses the issue and upgrades the dependencies, while unpinning some for better deduplication. All tests pass, the change is 100% backwards-compatible.

This change would deduplicate 3 dependencies.

https://npmgraph.js.org/?q=ipfs-car#select=exact%3A%40multiformats%2Fmurmur3%401.1.3